### PR TITLE
Add dial timeout by default

### DIFF
--- a/vm/ssh.go
+++ b/vm/ssh.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"net"
+	"time"
+
+	ssh "golang.org/x/crypto/ssh"
+)
+
+type Conn struct {
+	net.Conn
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+}
+
+func (c *Conn) Read(b []byte) (int, error) {
+	err := c.Conn.SetReadDeadline(time.Now().Add(c.ReadTimeout))
+	if err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(b)
+}
+
+func (c *Conn) Write(b []byte) (int, error) {
+	err := c.Conn.SetWriteDeadline(time.Now().Add(c.WriteTimeout))
+	if err != nil {
+		return 0, err
+	}
+	return c.Conn.Write(b)
+}
+
+func SSHDialTimeout(network, addr string, config *ssh.ClientConfig, timeout time.Duration) (*ssh.Client, error) {
+	conn, err := net.DialTimeout(network, addr, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	timeoutConn := &Conn{conn, timeout, timeout}
+	c, chans, reqs, err := ssh.NewClientConn(timeoutConn, addr, config)
+	if err != nil {
+		return nil, err
+	}
+	client := ssh.NewClient(c, chans, reqs)
+
+	go func() {
+		t := time.NewTicker(2 * time.Second)
+		defer t.Stop()
+		for range t.C {
+			_, _, err := client.Conn.SendRequest("keepalive@golang.org", true, nil)
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return client, nil
+}


### PR DESCRIPTION
This sets dialing timeout on SSH calls by default and drops the switch. It could happen that if the
remote part doesn't shutdown the SSH connection properly, the connection
on golang could sit on ssh.Wait().

Setting a Dial timeout allows the client to poke with keep-alives and if
the remote part doesn't answer in a timeframe the connection is closed.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>