### PR TITLE
Fix checking for wrong message on reset

### DIFF
--- a/helpers/poll.go
+++ b/helpers/poll.go
@@ -78,12 +78,12 @@ func (cf ConditionFunc) WithContext() ConditionWithContextFunc {
 	}
 }
 
-// Poll by interval and a timeout for a given condiction
+// PollImmediate Poll by interval and a timeout for a given condiction
 func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
 	return PollImmediateWithContext(context.Background(), interval, timeout, condition.WithContext())
 }
 
-// Poll by interval and a timeout for a given condiction with a context
+// PollImmediateWithContext Poll by interval and a timeout for a given condiction with a context
 func PollImmediateWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
 	return poll(ctx, true, poller(interval, timeout), condition)
 }
@@ -190,7 +190,7 @@ func poller(interval, timeout time.Duration) WaitWithContextFunc {
 
 // WaitForWithContext continually checks 'fn' as driven by 'wait'.
 //
-// WaitForWithContext gets a channel from 'wait()'', and then invokes 'fn'
+// WaitForWithContext gets a channel from 'wait()”, and then invokes 'fn'
 // once for every value placed on the channel and once more when the
 // channel is closed. If the channel is closed and 'fn'
 // returns false without error, WaitForWithContext returns ErrWaitTimeout.

--- a/vm/sut.go
+++ b/vm/sut.go
@@ -175,7 +175,7 @@ func (s *SUT) Reset() {
 	By("Running elemental reset")
 	out, err := s.command("elemental reset")
 	Expect(err).ToNot(HaveOccurred())
-	Expect(out).Should(ContainSubstring("Installing"))
+	Expect(out).Should(ContainSubstring("Reset"))
 
 	By("Reboot to active after elemental reset")
 	s.Reboot()


### PR DESCRIPTION
We were lokking for an Installing message that may not appear.

This patch changes that to look for the Reset message which is only written if reset command is called

Signed-off-by: itxaka <igarcia@suse.com>