### PR TITLE
Revert "Use grub_oem_env instead of grubenv"

### DIFF
--- a/vm/sut.go
+++ b/vm/sut.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	grubSwapOnce = "grub2-editenv /oem/grub_oem_env set next_entry=%s"
-	grubSwap     = "grub2-editenv /oem/grub_oem_env set saved_entry=%s"
+	grubSwapOnce = "grub2-editenv /oem/grubenv set next_entry=%s"
+	grubSwap     = "grub2-editenv /oem/grubenv set saved_entry=%s"
 
 	Passive     = "passive"
 	Active      = "active"


### PR DESCRIPTION
This reverts commit 938e65fa07d47ef9898d16ae0e6496c2487e4f74.