### PR TITLE
Fix Rancher Manager installation

### DIFF
--- a/rancher/install.go
+++ b/rancher/install.go
@@ -59,7 +59,6 @@ func DeployRancherManager(hostname, channel, version, ca, proxy string) error {
 		"--set", "extraEnv[1].name=CATTLE_BOOTSTRAP_PASSWORD",
 		"--set", "extraEnv[1].value=" + password,
 		"--set", "replicas=1",
-		"--set", "global.cattle.psp.enabled=false",
 	}
 
 	// Set specified version if needed


### PR DESCRIPTION
Since Rancher v2.7.5 we don't need to set `global.cattle.psp.enabled` to `false` anymore (see official docs).