### PR TITLE
Add RunHelmBinaryWithOutput

### DIFF
--- a/kubectl/kubectl.go
+++ b/kubectl/kubectl.go
@@ -777,6 +777,15 @@ func RunHelmBinaryWithCustomErr(args ...string) error {
 	return nil
 }
 
+// RunHelmBinaryWithOutput executes a desired binary and returns the output
+func RunHelmBinaryWithOutput(args ...string) (string, error) {
+	out, err := runBinary(helmCmd, args...)
+	if err != nil {
+		return string(out), &CustomError{strings.Join(append([]string{helmCmd}, args...), " "), string(out), err}
+	}
+	return string(out), nil
+}
+
 // runBinary executes a binary cmd and returns the stdOutput and stdError combined
 func runBinary(binaryName string, args ...string) ([]byte, error) {
 	cmd := exec.Command(binaryName, args...)

--- a/rancher/install.go
+++ b/rancher/install.go
@@ -15,6 +15,7 @@ limitations under the License.
 package rancher
 
 import (
+	"os"
 	"strings"
 
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
@@ -33,7 +34,10 @@ import (
  */
 // NOTE: AddNode does not have unit test as it is not easy to mock
 func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy string) error {
-	const password = "rancherpassword"
+	var password = "rancherpassword"
+	if envPW := os.Getenv("RANCHER_PASSWORD"); envPW != "" {
+		password = envPW
+	}
 	channelName := "rancher-" + channel
 
 	// Add Helm repository


### PR DESCRIPTION
Add RunHelmBinaryWithOutput to obtain the command output. Useful when running commands like `helm list`.

Also, allow to fetch rancher password using env `RANCHER_PASSWORD`.