### PR TITLE
Fix Rancher bootstrap password configuration

### DIFF
--- a/rancher/install.go
+++ b/rancher/install.go
@@ -61,8 +61,6 @@ func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy str
 		"--set", "bootstrapPassword=" + password,
 		"--set", "extraEnv[0].name=CATTLE_SERVER_URL",
 		"--set", "extraEnv[0].value=https://" + hostname,
-		"--set", "extraEnv[1].name=CATTLE_BOOTSTRAP_PASSWORD",
-		"--set", "extraEnv[1].value=" + password,
 		"--set", "replicas=1",
 	}
 


### PR DESCRIPTION
`CATTLE_BOOTSTRAP_PASSWORD` is not useful anymore since Rancher v2.7, in fact using it with `bootstrapPassword` leads to a warning in the logs:
```
W0227 14:15:37.680866 1 warnings.go:70] spec.template.spec.containers[0].env[4].name: duplicate name "CATTLE_BOOTSTRAP_PASSWORD"
```