### PR TITLE
Add support for Prime channel and 2.7-head on stgregistry

### DIFF
--- a/rancher/install.go
+++ b/rancher/install.go
@@ -56,7 +56,7 @@ func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy str
 		return err
 	}
 
-	if err = kubectl.RunHelmBinaryWithCustomErr("repo", "update"); err != nil {
+	if err := kubectl.RunHelmBinaryWithCustomErr("repo", "update"); err != nil {
 		return err
 	}
 

--- a/rancher/install.go
+++ b/rancher/install.go
@@ -52,8 +52,7 @@ func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy str
 	}
 
 	// Add Helm repository
-	err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", channelName, chartRepo)
-	if err != nil {
+	if err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", channelName, chartRepo); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds a support for new helm chart channel `prime` for Rancher installations.

Now it is able to use `prime/2.7.12` or `prime/devel/2.7` in addition.

Note: I found out that `rancher/rancher:v2.7-head` images are not getting released on dockerhub anymore. So when `headVersion == 2.7` it will use `stgregistry.suse.com/rancher/rancher:v2.7-head` image.
