### PR TITLE
Add support for Alpha channel

### DIFF
--- a/rancher/install.go
+++ b/rancher/install.go
@@ -45,6 +45,8 @@ func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy str
 	switch channel {
 	case "prime":
 		chartRepo = "https://charts.rancher.com/server-charts/prime"
+	case "alpha":
+		chartRepo = "https://releases.rancher.com/server-charts/alpha"
 	case "latest":
 		chartRepo = "https://releases.rancher.com/server-charts/latest"
 	case "stable":


### PR DESCRIPTION
To be able test `2.9.0-alpha1` I've added a Alpha channel where the chart is present, the alpha should be installable by `alpha/2.9.0-alpha1` rancher_version value.