### PR TITLE
Fix get cluster for Rancher Manager 2.9

### DIFF
--- a/rancher/rancher.go
+++ b/rancher/rancher.go
@@ -36,7 +36,8 @@ const noExist = "'%s' does not exist!"
  * @returns Cluster informations in *c or an error
  */
 func (c *Cluster) getCluster(ns, name string) error {
-	out, err := kubectl.Run("get", "cluster",
+	out, err := kubectl.Run("get",
+		"cluster.v1.provisioning.cattle.io",
 		"--namespace", ns, name,
 		"-o", "yaml")
 	if err != nil {


### PR DESCRIPTION
The default Cluster Kind is now set to `apiVersion cluster.x-k8s.io/v1beta1`, we need to force the old behaviour. This way the `getCluster` function will still be compatible with older and newer version of Rancher Manager 2.x.