### PR TITLE
Add channel prime_optimus_alpha to rancher install

### DIFF
--- a/rancher/install.go
+++ b/rancher/install.go
@@ -61,6 +61,9 @@ func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy str
 		chartRepo = "https://charts.rancher.com/server-charts/prime"
 	case "prime-optimus":
 		chartRepo = "https://charts.optimus.rancher.io/server-charts/latest"
+	case "prime-optimus-alpha":
+		chartRepo = "https://charts.optimus.rancher.io/server-charts/alpha"
+		flags = append(flags, "--devel")
 	case "alpha":
 		chartRepo = "https://releases.rancher.com/server-charts/alpha"
 		flags = append(flags, "--devel")


### PR DESCRIPTION
Recently, I saw that `Rancher 2.8.8-alpha1` is pushed to `charts.optimus.rancher.io/server-charts/alpha`.

I searched for all available channels but didn't find the `Rancher 2.8.8-alpha1`. Later search on alpha of optimus prime registry.

Below are my findings:

```
satya@opensuse15:~> helm repo add rancher-prime-optimus-alpha "https://charts.optimus.rancher.io/server-charts/alpha"
"rancher-prime-optimus-alpha" has been added to your repositories

satya@opensuse15:~> helm repo up

satya@opensuse15:~> helm search repo rancher-prime-optimus-alpha -l --devel | grep 2.8.8
rancher-prime-optimus-alpha/rancher	2.8.8-alpha1 	v2.8.8-alpha1 	Install Rancher Server to manage Kubernetes clu...

```

I hope this PR will help to extend the CI's to adopt new channel and install `Rancher 2.8.8-alpha1` and future versions from there.