### PR TITLE
Use a well-known kind actions in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,10 +25,8 @@ jobs:
           key: ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
-      - name: Install Kind
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: "v0.11.1"
+      - name: Install K8s Kind Cluster
+        uses: helm/kind-action@v1
       - name: Run tests
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION
engineerd/setup-kind is not a validated one, better to use helm/kind-action instead.