### PR TITLE
Improve pod status check in NamespaceWithReadyPod

### DIFF
--- a/kubectl/kubectl.go
+++ b/kubectl/kubectl.go
@@ -112,6 +112,12 @@ func (k *Kubectl) NamespaceWithReadyPod(namespace string, labelName string) (boo
 			if !s.Ready {
 				return false, nil
 			}
+			if !s.Started {
+				return false, nil
+			}
+			if s.State.Running == nil {
+				return false, nil
+			}
 		}
 	}
 	return true, nil

--- a/kubectl/pod.go
+++ b/kubectl/pod.go
@@ -74,7 +74,7 @@ type ContainerStatus struct {
 	Image                string         `yaml:"image"`
 	ImageID              string         `yaml:"imageID"`
 	ContainerID          string         `yaml:"containerID,omitempty"`
-	Started              *bool          `yaml:"started,omitempty"`
+	Started              bool           `yaml:"started,omitempty"`
 }
 
 // PodCondition is the pod condition status


### PR DESCRIPTION
Checking that the pod's status is Ready is not enough, we have to be sure that Started is set too as well as checking that containers are really in Running state. Otherwise we validate that the Pods are OK even if they are still in creating/starting process, which can take some times to end.

Verification runs for this PR can be found here: https://github.com/rancher/elemental/pull/1593.