### PR TITLE
Add support for head and case for v2.10-head

### DIFF
--- a/rancher/install.go
+++ b/rancher/install.go
@@ -28,13 +28,20 @@ import (
  */
 func appendDevelFlags(flags []string, headVersion string) []string {
 	switch headVersion {
-	case "2.10":
+	case "head":
 		flags = append(flags,
 			"--devel",
 			"--set", "rancherImageTag=head",
 			"--set", "extraEnv[1].name=CATTLE_AGENT_IMAGE",
 			"--set", "extraEnv[1].value=rancher/rancher-agent:head",
 		)
+	case "2.10":
+		flags = append(flags,
+			"--devel",
+			"--set", "rancherImageTag=v"+headVersion+"-head",
+			"--set", "extraEnv[1].name=CATTLE_AGENT_IMAGE",
+			"--set", "extraEnv[1].value=rancher/rancher-agent:v"+headVersion+"-head",
+		)	
 	default:
 		// Devel images for rancher:v2\.(7|8|9)-head are available on stgregistry.suse.com
 		flags = append(flags,


### PR DESCRIPTION
- `release/v2.10` branch is now created and images are being pushed to dockerhub [v2.10-head](https://hub.docker.com/layers/rancher/rancher/v2.10-head/images/sha256-9752b169479f6dbaa1b32537f7562a2de849c68c873e0e5ac5794d386d347566?context=explore)
- head tag is also present on dockerhub referring to `main` rancher branch

Go playground: https://go.dev/play/p/LewdeOor2GX