### PR TITLE
Add --force-update flag while adding repo to avoid 'already exists' error

### DIFF
--- a/rancher/install.go
+++ b/rancher/install.go
@@ -128,7 +128,7 @@ func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy str
 	}
 
 	// Add Helm repository
-	if err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", channelName, chartRepo); err != nil {
+	if err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", channelName, chartRepo, "--force-update"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Add `--force-update` flag while adding rancher repo. This will avoid unnecessary error in case the repository already exists.

```sh
❯ helm repo list
NAME                 	URL                                                                             
rancher-stable       	https://releases.rancher.com/server-charts/stable                               
rancher-latest       	https://releases.rancher.com/server-charts/latest/                              
rancher-alpha        	https://releases.rancher.com/server-charts/alpha                                

❯ helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
Error: repository name (rancher-latest) already exists, please specify a different name

❯ helm repo add rancher-latest https://releases.rancher.com/server-charts/latest --force-update
"rancher-latest" has been added to your repositories

```