### PR TITLE
Updated switch case to include 2.11 onwards

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,8 @@ run:
   timeout: 5m
   tests: false
 output:
-  format: github-actions
+  formats: 
+  - format: colored-line-number
 linters:
   enable:
     - revive # replacement for golint

--- a/http/get.go
+++ b/http/get.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/http/server.go
+++ b/http/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kubectl/kubectl.go
+++ b/kubectl/kubectl.go
@@ -1,7 +1,7 @@
 //nolint:goheader
 /*
 Copyright © 2021 Cloudfoundry (https://github.com/cloudfoundry-incubator/quarks-utils)
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kubectl/kubectl_suite_test.go
+++ b/kubectl/kubectl_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kubectl/kubectl_test.go
+++ b/kubectl/kubectl_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kubectl/pod.go
+++ b/kubectl/pod.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rancher/cluster.go
+++ b/rancher/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rancher/install.go
+++ b/rancher/install.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rancher/install.go
+++ b/rancher/install.go
@@ -16,6 +16,7 @@ package rancher
 
 import (
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
@@ -27,15 +28,21 @@ import (
  * @returns flags with correct values
  */
 func appendDevelFlags(flags []string, headVersion string) []string {
-	switch headVersion {
-	case "head":
+
+	// Regex pattern for 2.10, 2.11 and so on but not 2.7, 2.8 or 2.9
+	pattern := `^[2-9]\.(10|1[1-9]|[2-9]\d)$`
+	re := regexp.MustCompile(pattern)
+
+	switch {
+	case headVersion == "head":
 		flags = append(flags,
 			"--devel",
 			"--set", "rancherImageTag=head",
 			"--set", "extraEnv[1].name=CATTLE_AGENT_IMAGE",
 			"--set", "extraEnv[1].value=rancher/rancher-agent:head",
 		)
-	case "2.10":
+	case re.MatchString(headVersion):
+		// If the version matches the regex, like 2.10, 2.11, etc.
 		flags = append(flags,
 			"--devel",
 			"--set", "rancherImageTag=v"+headVersion+"-head",

--- a/rancher/qemu.go
+++ b/rancher/qemu.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rancher/qemu_test.go
+++ b/rancher/qemu_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rancher/rancher.go
+++ b/rancher/rancher.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rancher/rancher_suite_test.go
+++ b/rancher/rancher_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tools/tools_suite_test.go
+++ b/tools/tools_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vm/ssh.go
+++ b/vm/ssh.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vm/sut.go
+++ b/vm/sut.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vm/sut_test.go
+++ b/vm/sut_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vm/systemd.go
+++ b/vm/systemd.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vm/vm_suite_test.go
+++ b/vm/vm_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2024 SUSE LLC
+Copyright © 2022 - 2025 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes: #69 
Fixed: 
- `golangci-lint`
- Changed license year.