### PR TITLE
Add support for new 2.10, 2.11 and 2.12 head channels

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,8 @@ linters:
     - goimports # check imports
     - gocyclo # check complexity
 linters-settings:
+  goconst:
+      min-occurrences: 6  # Increase from default 3 to 6, so "head" with 5 occurrences won't trigger
   gocyclo:
     min-complexity: 30
   goheader:


### PR DESCRIPTION
This PR brings support for new `head` helm charts for installing `2.10`, `2.11` and `2.12` head builds of rancher.

It is still backward compatible with `latest/devel/head` approach but then the images are most likely outdated and "unsupported".

To provision rancher from "official" `head` chart repos, please change your pipelines to use:
* `RANCHER_VERSION=head/2.12` (head/head is not available)
 or 
* `RANCHER_VERSION=head/devel/2.12`

~Be warned, that the current code is adding extraEnv for `CATTLE_AGENT_IMAGE` which will be probably a subject of future changes. But so far without setting the env the downstream clusters are `Pending` forever as the chart uses wrong docker.io registry for `rancher-agent` pod (in 2.10 and 2.11, not a problem in 2.12 which uses docker.io for all images)~

~Go playground: https://go.dev/play/p/qEn61wJP0cS~

~!!! BROKEN 07/05/25 switching to DRAFT - downstream clusters still pull rancher-agent from docker.io - tested on 2.11-head
UPDATE 07/05/25: Pedro merged commits for [2.10](https://github.com/rancher/rancher/pull/50930) and [2.11](https://github.com/rancher/rancher/pull/50928) setting correct REGISTRY for rancher-agent pod image so there is no need to set extraEnv anymore.~

Go playground:  https://go.dev/play/p/qkIWR9mrliw
UPDATE 07/10/25: the new `head` channels are working for all versions.