### PR TITLE
Fix release name for all prime 2.13 and use force update when adding …

### DIFF
--- a/rancher/install.go
+++ b/rancher/install.go
@@ -129,10 +129,10 @@ func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy str
 		channelName = channelName + "-" + headVersion
 	}
 
-	// As of 11/25 different chart name for prime-alpha and prime-rc channels was introduced for Rancher v2.13.x
+	// As of 11/25 different chart name for prime channels was introduced for Rancher v2.13.x
 	// Later we can assume the same for v2.12.5 but it is not released nor implemented yet
 	var rancherChartName string
-	if strings.Contains(channelName, "prime-") && strings.Contains(version, "2.13.") {
+	if strings.Contains(channelName, "prime") && strings.Contains(version, "2.13.") {
 		rancherChartName = "rancher-prime"
 	} else {
 		rancherChartName = "rancher"
@@ -171,7 +171,7 @@ func DeployRancherManager(hostname, channel, version, headVersion, ca, proxy str
 	}
 
 	// Add Helm repository
-	if err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", channelName, chartRepo); err != nil {
+	if err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", channelName, chartRepo, "--force-update"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
…repo

This is fix for prime release name on 2.13 - it was working fine for alphas but not for official released versions.

also adding fix from https://github.com/rancher-sandbox/ele-testhelpers/pull/68

https://go.dev/play/p/ezswGhstCrH

```
prime/2.13.1, NO proxy, NO extraFlags
repo add rancher-prime https://charts.rancher.com/server-charts/prime
repo update
[upgrade --install rancher-prime rancher-prime/rancher-prime --namespace cattle-system --create-namespace --set hostname=my.awesome.domain --set bootstrapPassword=rancherpassword --set extraEnv[0].name=CATTLE_SERVER_URL --set extraEnv[0].value=https://my.awesome.domain --set replicas=1 --set useBundledSystemChart=true --wait --wait-for-jobs --version 2.13.1]

prime-alpha/2.13.0-alpha7, NO proxy, NO extraFlags
repo add rancher-prime-alpha https://charts.optimus.rancher.io/server-charts/alpha
repo update
[upgrade --install rancher-prime rancher-prime-alpha/rancher-prime --namespace cattle-system --create-namespace --set hostname=my.awesome.domain --set bootstrapPassword=rancherpassword --set extraEnv[0].name=CATTLE_SERVER_URL --set extraEnv[0].value=https://my.awesome.domain --set replicas=1 --set useBundledSystemChart=true --wait --wait-for-jobs --devel --version 2.13.0-alpha7 --set rancherImage=stgregistry.suse.com/rancher/rancher --set extraEnv[1].name=CATTLE_AGENT_IMAGE --set extraEnv[1].value=stgregistry.suse.com/rancher/rancher-agent:v2.13.0-alpha7]
```